### PR TITLE
Add missing required modules

### DIFF
--- a/application/fibo_helper_service/CMakeLists.txt
+++ b/application/fibo_helper_service/CMakeLists.txt
@@ -19,7 +19,7 @@ cmake_minimum_required(VERSION 3.6)
 project(fibo_helper_service)
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(deps REQUIRED IMPORTED_TARGET glib-2.0 gio-2.0 gio-unix-2.0)
+pkg_check_modules(deps REQUIRED IMPORTED_TARGET libudev glib-2.0 gio-2.0 gio-unix-2.0 dbus-1 mbim-glib mm-glib)
 
 ##################################
 # Fibocom linux Gdbus codegen


### PR DESCRIPTION
Fix error:
=====================
In file included from /home/kchsieh/Workspace/fibocom/fibocom_linux_apps_opensource/application/fibo_helper_service/fibo_helper_main.c:24: /home/kchsieh/Workspace/fibocom/fibocom_linux_apps_opensource/application/fibo_helper_service/fibo_helper_basic_func.h:27:10: fatal error: libmbim-glib.h: No such file
 or directory
   27 | #include "libmbim-glib.h"
      |          ^~~~~~~~~~~~~~~~
compilation terminated.
====================
and
====================
/home/kchsieh/Workspace/fibocom/fibocom_linux_apps_opensource/application/fibo_helper_service/fibo_helper_basic_func.c:25:10: fatal error: libmm-glib.h: No such file or directory
   25 | #include <libmm-glib.h>
      |          ^~~~~~~~~~~~~~
compilation terminated.
===================